### PR TITLE
Add ability to set auto-reconnect with the MySQL gem, and ensure that we can require it as well.

### DIFF
--- a/lib/hiera/backend/mysql_backend.rb
+++ b/lib/hiera/backend/mysql_backend.rb
@@ -58,7 +58,7 @@ class Hiera
                 mysql_database=Config[:mysql][:database]
 
                 dbh = Mysql.new(mysql_host, mysql_user, mysql_pass, mysql_database)
-                dhb.reconnect = true
+                dbh.reconnect = true
                 
                 res = dbh.query(sql)
                 Hiera.debug("Mysql Query returned #{res.num_rows} rows")


### PR DESCRIPTION
This is to make sure that we have the ability to require the MySQL gem, plus that the driver will reconnect automatically to the MySQL database in case of it going away i.e. somebody restarted MySQL and/or there were some networking-related issues, primarily to avoid pesky "Mysql::Error" exception "MySQL server has gone away".
