### PR TITLE
Adapating mysql_backend.rb to interact with puppet hiera_hash() function

### DIFF
--- a/lib/hiera/backend/mysql_backend.rb
+++ b/lib/hiera/backend/mysql_backend.rb
@@ -36,6 +36,10 @@ class Hiera
                             results.each do |ritem|
                                 answer << Backend.parse_answer(ritem, scope)
                             end
+                        when :hash
+                            results.each do |ritem|
+                                answer[Backend.parse_answer(ritem, scope)] = Hash.new
+                            end
                         else
                             answer = Backend.parse_answer(results[0], scope)
                         end

--- a/lib/hiera/backend/mysql_backend.rb
+++ b/lib/hiera/backend/mysql_backend.rb
@@ -12,7 +12,7 @@ class Hiera
                   require 'rubygems'
                   require 'mysql'
                 end
-                
+
                 Hiera.debug("mysql_backend initialized")
             end
             def lookup(key, scope, order_override, resolution_type)
@@ -26,7 +26,15 @@ class Hiera
                 mysql_query = Backend.parse_string(Config[:mysql][:query], scope, { "key" => key })
 
 
-                answer = Backend.empty_answer(resolution_type)
+                case resolution_type
+                  when :array
+                    answer = []
+                  when :hash
+                    answer = {}
+                  else
+                    answer = nil
+                end
+
                 Hiera.debug("resolution type is #{resolution_type}")
 
                 results = query(mysql_query)


### PR DESCRIPTION
This pull request aims to fix the behavior of the mysql_backend.rb, when used with hiera_hash() puppet function.

In order to use correctly, create_resources function, the second parameter needs to be a hash.

```ruby
create_resources(file, hiera_hash('x'))
```

Currently, it wasn't returning in the form it should have. This patch fixes it.