### PR TITLE
Provide a way to filter hiera-mysql lookups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Here is a sample hiera.yaml file that will work with mysql
     :database: config
 
     :query: SELECT val FROM configdata WHERE var='%{key}' AND environment='%{env}'
+    :keyregex: !ruby/regexp '/mymodule:/'
 
 
 :logger: console
@@ -54,6 +55,7 @@ Here is a sample hiera.yaml file that will work with mysql
       - SELECT val FROM configdata WHERE var='%{key}' AND environment='common'
 </pre>
 
+:keyregex: is an optional parameter that can be used to specify a regular expression that the key must match in order for the mysql lookup to be invoked.  In the sample hiera.yaml, the mysql backend is only used to lookup keys from a specific module.
 Results and data types
 ======================
 


### PR DESCRIPTION
Hi
I've modified hiera-mysql to include the capability of filtering which queries get executed based on a regular expression that must match the key to be looked up.

Why did I do this?

I was thinking of using the hiera-mysql backend to lookup some data directly from my zabbix backend database.

As such, I use a query like

:query: select host from hosts where hostid = (SELECT proxy_hostid from hosts where host='%{hostname}') and 'zabbix::agent::server'='%{key}'

This works, but the database gets all lookups including queries it will never return values for. (ie where key != zabbix::agent::server)

I've not written/touched any ruby before, so sorry for the code quality of my patch! :(

Kind Regards,
Alex

